### PR TITLE
Use the filenames of the contestant as a default submission comment

### DIFF
--- a/cms/server/contest/submission/workflow.py
+++ b/cms/server/contest/submission/workflow.py
@@ -196,11 +196,15 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
     logger.info("All files stored for submission sent by %s",
                 participation.user.username)
 
+    # Use the filenames of the contestant as a default submission comment
+    received_filenames_joined = ",".join([file.filename for file in received_files])
+
     submission = Submission(
         timestamp=timestamp,
         language=language.name if language is not None else None,
         task=task,
         participation=participation,
+        comment=received_filenames_joined,
         official=official)
     sql_session.add(submission)
 


### PR DESCRIPTION
It is very useful for the scientific commitee to see it in the Comment column of the submissions page in the admin website. This column was mostly unused and empty in the past.